### PR TITLE
Ability to use hash in column name

### DIFF
--- a/lib/RapidApp/TableSpec.pm
+++ b/lib/RapidApp/TableSpec.pm
@@ -18,7 +18,7 @@ sub BUILD {
 
 has 'ResultClass' => ( is => 'ro', isa => 'Str' );
 
-has 'name' => ( is => 'ro', isa => 'Str', required => 1 );
+has 'name' => ( is => 'ro', isa => 'Str|ScalarRef[Str]', required => 1 );
 has 'title' => ( is => 'ro', isa => 'Maybe[Str]', default => undef );
 has 'iconCls' => ( is => 'ro', isa => 'Maybe[Str]', default => undef );
 


### PR DESCRIPTION
We use columns like `abc#defgh` (Its pretty ugly.)
But they seem to work ok with DBIx::Class.
The change here should allow the "hash in the middle of a column name" to work.