### PR TITLE
Simplify end-of-line code

### DIFF
--- a/devel/convert_to_moo.pl
+++ b/devel/convert_to_moo.pl
@@ -35,11 +35,10 @@ $start_dir->recurse(
     if (-f $File && $File =~ /.pm$/) {
       my @lines = $File->slurp(iomode => '<:encoding(UTF-8)');
       my @nlines = ();
+      my $nl = "\n";
       my $ch = 0;
       for my $line (@lines) {
       
-        $line =~ /(\r?\n)$/;
-        my $nl = $1;
         $line =~ s/\r?\n$//;
         my $orig = $line;
      
@@ -131,7 +130,6 @@ $start_dir->recurse(
         
         unless ($line eq $orig) {
           $ch++;
-          $nl = "\n";
         }
         push @nlines, $line, $nl;
       }


### PR DESCRIPTION
The utility does not preserve end-of-line, so this code was removed.  Tested with Linux \n and Windows \r\n files.  If you intended to preserve line-endings, I can do that instead.  The original code preserved line endings unless a line was converted, and the current code always adds native line-endings appropriate for the user's platform via "\n".