### PR TITLE
RapidApp CoreSchema session logout bugfix

### DIFF
--- a/lib/Catalyst/Plugin/RapidApp/AuthCore/Controller/Auth.pm
+++ b/lib/Catalyst/Plugin/RapidApp/AuthCore/Controller/Auth.pm
@@ -34,8 +34,8 @@ sub logout :Local :Args(0) {
   my $self = shift;
   my $c = shift;
   
-  $c->logout;
   $c->delete_session('logout');
+  $c->logout;
   $c->delete_expired_sessions;
   
   return $self->do_redirect($c);


### PR DESCRIPTION
While testing RapidApp CoreSchema with mysql, I encountered the
problem of "row not found". After deeper analyze of the situation
around Session and RapidApp, i saw that actually the code was doing
logout and then deletes the session, which leads to this error. I am
still unsure why this problem doesn't pop up on the SQLite database.