### PR TITLE
Adding Shorten Tabs feature and fixing some more bugs around the tab

### DIFF
--- a/lib/Catalyst/Plugin/RapidApp/TabGui.pm
+++ b/lib/Catalyst/Plugin/RapidApp/TabGui.pm
@@ -101,7 +101,7 @@ before 'setup_components' => sub {
     navtree_footer_template
     navtree_load_collapsed
     navtree_disabled
-    shorten_tab_titles
+    tab_title_max_width
   );
   $config->{$_} and $main_module_params->{$_} = $config->{$_} for (@copy_params);
   

--- a/lib/Catalyst/Plugin/RapidApp/TabGui.pm
+++ b/lib/Catalyst/Plugin/RapidApp/TabGui.pm
@@ -101,6 +101,7 @@ before 'setup_components' => sub {
     navtree_footer_template
     navtree_load_collapsed
     navtree_disabled
+    shorten_tab_titles
   );
   $config->{$_} and $main_module_params->{$_} = $config->{$_} for (@copy_params);
   

--- a/lib/RapidApp/DBIC/Component/TableSpec.pm
+++ b/lib/RapidApp/DBIC/Component/TableSpec.pm
@@ -272,11 +272,12 @@ sub create_result_TableSpec {
 	
 	my $table = $ResultClass->table;
 	$table = (split(/\./,$table,2))[1] || $table; #<-- get 'table' for both 'db.table' and 'table' format
+
 	my $TableSpec = RapidApp::TableSpec->new( 
 		name => $table,
 		%opt
 	);
-	
+
 	my $data_types = $self->TableSpec_data_type_profiles;
 	
 	## WARNING! This logic overlaps with logic further down (in default_TableSpec_cnf_columns)

--- a/lib/RapidApp/Module/Explorer.pm
+++ b/lib/RapidApp/Module/Explorer.pm
@@ -42,7 +42,7 @@ has 'dashboard_url', is => 'ro', isa => 'Maybe[Str]', default => sub {undef};
 has 'navtree_footer_template', is => 'ro', isa => 'Maybe[Str]', default => sub {undef};
 
 # Totally new:
-has 'shorten_tab_titles', is => 'ro', isa => 'Bool', default => 0;
+has 'tab_title_max_width', is => 'ro', isa => 'Str', default => '300px';
 
 # Extra optional class for rendering any tt files or other files
 # Feature added with RapidApp::AppPageViewer in mind, but it doesn't
@@ -241,7 +241,7 @@ sub content_area {
     $cnf->{initLoadTabs} = [$initTab];
   }
   
-  $cnf->{shorten_tab_titles} = $self->shorten_tab_titles ? \1 : \0;
+  $cnf->{tab_title_max_width} = $self->tab_title_max_width;
 
   return  RapidApp::JSONFunc->new(
     func => 'new Ext.ux.RapidApp.AppTab.TabPanel',

--- a/lib/RapidApp/Module/Explorer.pm
+++ b/lib/RapidApp/Module/Explorer.pm
@@ -41,6 +41,9 @@ has 'dashboard_url', is => 'ro', isa => 'Maybe[Str]', default => sub {undef};
 # New:
 has 'navtree_footer_template', is => 'ro', isa => 'Maybe[Str]', default => sub {undef};
 
+# Totally new:
+has 'shorten_tab_titles', is => 'ro', isa => 'Bool', default => 0;
+
 # Extra optional class for rendering any tt files or other files
 # Feature added with RapidApp::AppPageViewer in mind, but it doesn't
 # actually care. This module will be loaded as 'page' and nothing else
@@ -238,6 +241,8 @@ sub content_area {
     $cnf->{initLoadTabs} = [$initTab];
   }
   
+  $cnf->{shorten_tab_titles} = $self->shorten_tab_titles ? \1 : \0;
+
   return  RapidApp::JSONFunc->new(
     func => 'new Ext.ux.RapidApp.AppTab.TabPanel',
     parm => $cnf

--- a/share/assets/css/040-RapidApp.css
+++ b/share/assets/css/040-RapidApp.css
@@ -1759,3 +1759,23 @@ a:hover, a:hover * { cursor: pointer; }
   word-break: break-all;
   white-space: normal;
 }
+
+/* Added for shorten_tab_titles feature by GETTY */
+
+.ra-short-tab-title {
+  width: 250px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.wrapword {
+  white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
+  white-space: -pre-wrap;      /* Opera 4-6 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  white-space: pre-wrap;       /* css-3 */
+  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+  white-space: -webkit-pre-wrap; /* Newer versions of Chrome/Safari*/
+  word-break: break-all;
+  white-space: normal;
+}

--- a/share/assets/css/040-RapidApp.css
+++ b/share/assets/css/040-RapidApp.css
@@ -1763,7 +1763,6 @@ a:hover, a:hover * { cursor: pointer; }
 /* Added for shorten_tab_titles feature by GETTY */
 
 .ra-short-tab-title {
-  max-width: 250px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/share/assets/css/040-RapidApp.css
+++ b/share/assets/css/040-RapidApp.css
@@ -1763,7 +1763,7 @@ a:hover, a:hover * { cursor: pointer; }
 /* Added for shorten_tab_titles feature by GETTY */
 
 .ra-short-tab-title {
-  width: 250px;
+  max-width: 250px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/share/assets/js/081-Plugin.js
+++ b/share/assets/js/081-Plugin.js
@@ -2468,6 +2468,7 @@ Ext.ux.RapidApp.Plugin.AppGridAutoColWidth = Ext.extend(Ext.util.Observable,{
 			
 			hmenu.insert(index,{
 				text: "AutoSize Columns",
+				itemId: 'autosize-columns',
 				iconCls: 'ra-icon-left-right',
 				handler:this.autoSizeColumns, //<-- this does the full autosize which could be slow
 				scope: this

--- a/share/assets/js/084-AppTab.js
+++ b/share/assets/js/084-AppTab.js
@@ -350,8 +350,8 @@ Ext.ux.RapidApp.AppTab.TabPanel = Ext.extend(Ext.TabPanel, {
 	          setTitle = '<span class="' + setTitleCls + '">' + setTitle + '</span>';
 					}
 
-					if (tp.shorten_tab_titles) {
-						setTitle = '<div class="ra-short-tab-title">' + setTitle + '</div>';
+					if (tp.tab_title_max_width) {
+						setTitle = '<div style="max-width:' + tp.tab_title_max_width + '" class="ra-short-tab-title">' + setTitle + '</div>';
 					}
 
 					tab.setTitle(setTitle);

--- a/share/assets/js/084-AppTab.js
+++ b/share/assets/js/084-AppTab.js
@@ -334,10 +334,15 @@ Ext.ux.RapidApp.AppTab.TabPanel = Ext.extend(Ext.TabPanel, {
 				}
 				
 				if (setTitle) {
-					// Even if the title includes new lines or <br>'s, those
-					// shouldn't be displayed in the title tab, so that the tab
-					// view is not going 2 lines - GETTY
-					setTitle = setTitle.replace(/(\r\n|\n|\r|<br>|<\/br>)/gm,"");
+					// We strip all HTML and new lines from the title to not
+					// let it pollute our tab or any other visual component.
+					// WARNING: Title must be trusted source, this method
+					// would still allow JS injection.
+					// - GETTY
+					setTitle = setTitle.replace(/(\r\n|\n|\r)/gm,"");
+					var textdiv = document.createElement("div");
+					textdiv.innerHTML = setTitle;
+					setTitle = textdiv.textContent || textdiv.innerText || "";
 
 					tab.raw_title = setTitle;
 


### PR DESCRIPTION
title and its dropdown. First I fixed the "Close other Tabs" menu
to be really not shown when there is no other tab open. I also added
"Close Tab" to allow to close the tab without actually reaching the
top right X. After that I reached out to understand how RapidApp
constructs the TabPanel, which leaded me to Module::Explorer, which
I extended with a shorten_tab_titles attribute, which can easily be
set on the Catalyst::Plugin::RapidApp::TabGui configuration. If
activated, we add a div around the title with the class
ra-shorten-tab-titles, which uses CSS to shorten the visual. Still,
when you right-click the menu will show you the full title, and it
will even word-wrap this title, so that you are able to see it all
even if its much longer as the screen. I also added filtering out
of returns and br's for the title, to not get a 2 lines tabpanel.