### PR TITLE
Implemented the capability for virtual columns to be a code ref. This

### DIFF
--- a/lib/RapidApp/CoreSchema/Result/Session.pm
+++ b/lib/RapidApp/CoreSchema/Result/Session.pm
@@ -96,7 +96,12 @@ __PACKAGE__->add_virtual_columns(
   expires_in => {
     data_type => "integer", 
     is_nullable => 1, 
-    sql => q|SELECT (self.expires - strftime('%s','now'))|
+    sql => sub {
+      # this is exactly the same method (with time()) how
+      # Catalyst::Plugin::Session::Store::DBIC is checking
+      # the session
+      'SELECT (self.expires - '.(time()).')'
+    },
   },
 );
 __PACKAGE__->apply_TableSpec;

--- a/lib/RapidApp/DBIC/Component/VirtualColumnsExt.pm
+++ b/lib/RapidApp/DBIC/Component/VirtualColumnsExt.pm
@@ -121,6 +121,8 @@ sub _virtual_column_select {
   if ($self->has_virtual_column($column)) {
     my $info = $self->column_info($column);
     my $sql = $info->{sql} or die "Missing virtual column 'sql' attr in info";
+    # also see RapidApp::TableSpec::Role::DBIC
+    $sql = $info->{sql}->($self, $column) if ref $sql eq 'CODE';
     my $rel = 'me';
     $sql =~ s/self\./${rel}\./g;
     $sql =~ s/\`self\`\./\`${rel}\`\./g; #<-- also support backtic quoted form (quote_sep)

--- a/lib/RapidApp/TableSpec/Role/DBIC.pm
+++ b/lib/RapidApp/TableSpec/Role/DBIC.pm
@@ -1366,6 +1366,8 @@ sub resolve_dbic_rel_alias_by_column_name  {
 			my $function = $info->{function} || sub {
 				my ($self,$rel,$col,$join,$cond_data2,$name2) = @_;
 				my $sql = $info->{sql} || 'SELECT(NULL)';
+				# also see RapidApp::DBIC::Component::VirtualColumnsExt
+				$sql = $info->{sql}->($self->ResultClass, $col) if ref $sql eq 'CODE';
 				
 				# ** translate 'self.' into the relname of the current context. This
 				# should either be 'me.' or the join name. This logic is important


### PR DESCRIPTION
coderef gets called with the ResultSet class of the column and the
column and should throw back the same SQL that is expected with the
code ref on this variable. Sadly this is taken out at 2 different
places, this should be put into a function for the future and so
normalize those 2 places.