### PR TITLE
Caching colspec startup

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -89,6 +89,7 @@ Text::CSV                     = 1.32
 HTML::Parser                  = 3.71
 HTML::TokeParser::Simple      = 3.16
 URI::Escape                   = 3.31
+CHI                           = 0.59
 
 MIME::Base64                  = 3.13
 Storable                      = 2.51

--- a/lib/Catalyst/Plugin/RapidApp/AuthCore/Controller/Auth.pm
+++ b/lib/Catalyst/Plugin/RapidApp/AuthCore/Controller/Auth.pm
@@ -8,8 +8,10 @@ use RapidApp::Util qw(:all);
 require Module::Runtime;
 require Catalyst::Utils;
 
+sub base :Chained :PathPrefix :CaptureArgs(0) {}
+
 # 'login' is the POST target of the new HTML login form:
-sub login :Chained('/') :PathPart('auth/login') :Args(0) {
+sub login :Chained('base') :Args(0) {
   my $self = shift;
 	my $c = shift;
   
@@ -30,7 +32,7 @@ sub login :Chained('/') :PathPart('auth/login') :Args(0) {
   return $self->do_redirect($c);
 }
 
-sub logout :Chained('/') :PathPart('auth/logout')  :Args(0) {
+sub logout :Chained('base') :Args(0) {
   my $self = shift;
   my $c = shift;
   
@@ -65,7 +67,7 @@ sub do_redirect {
 }
 
 # For session timeout, re-auth by RapidApp JavaScript client:
-sub reauth :Chained('/') :PathPart('auth/reauth') :Args(0) {
+sub reauth :Chained('base') :Args(0) {
 	my $self = shift;
 	my $c = shift;
 	

--- a/lib/Catalyst/Plugin/RapidApp/AuthCore/Controller/Auth.pm
+++ b/lib/Catalyst/Plugin/RapidApp/AuthCore/Controller/Auth.pm
@@ -9,7 +9,7 @@ require Module::Runtime;
 require Catalyst::Utils;
 
 # 'login' is the POST target of the new HTML login form:
-sub login :Local :Args(0) {
+sub login :Chained('/') :PathPart('auth/login') :Args(0) {
   my $self = shift;
 	my $c = shift;
   
@@ -30,7 +30,7 @@ sub login :Local :Args(0) {
   return $self->do_redirect($c);
 }
 
-sub logout :Local :Args(0) {
+sub logout :Chained('/') :PathPart('auth/logout')  :Args(0) {
   my $self = shift;
   my $c = shift;
   
@@ -65,7 +65,7 @@ sub do_redirect {
 }
 
 # For session timeout, re-auth by RapidApp JavaScript client:
-sub reauth :Local :Args(0) {
+sub reauth :Chained('/') :PathPart('auth/reauth') :Args(0) {
 	my $self = shift;
 	my $c = shift;
 	

--- a/lib/Catalyst/Plugin/RapidApp/NavCore/Controller.pm
+++ b/lib/Catalyst/Plugin/RapidApp/NavCore/Controller.pm
@@ -13,7 +13,7 @@ use JSON qw(decode_json);
 # Controller for loading a saved search in CoreSchema via ID
 
 
-sub load :Path :Args(1) {
+sub load :Chained('/') :PathPart('view') :Args(1) {
   my ( $self, $c, $search_id ) = @_;
   
   ## ---

--- a/lib/Catalyst/Plugin/RapidApp/NavCore/Controller.pm
+++ b/lib/Catalyst/Plugin/RapidApp/NavCore/Controller.pm
@@ -12,8 +12,7 @@ use JSON qw(decode_json);
 
 # Controller for loading a saved search in CoreSchema via ID
 
-
-sub load :Chained('/') :PathPart('view') :Args(1) {
+sub load :Chained :PathPart('view') :Args(1) {
   my ( $self, $c, $search_id ) = @_;
   
   ## ---

--- a/lib/RapidApp.pm
+++ b/lib/RapidApp.pm
@@ -28,7 +28,6 @@ our $ACTIVE_REQUEST_CONTEXT = undef;
 
 sub active_request_context { $ACTIVE_REQUEST_CONTEXT }
 
-
 # Convenience wrapper around RapidApp::Builder
 sub build_app {
   shift if ($_[0] && $_[0] eq __PACKAGE__);

--- a/lib/RapidApp/Controller/DefaultRoot.pm
+++ b/lib/RapidApp/Controller/DefaultRoot.pm
@@ -63,33 +63,16 @@ features could also be easily plugged into a custom top controller.
 before 'COMPONENT' => sub {
   my $class = shift;
   my $app_class = ref $_[0] || $_[0];
-  
-  my $ns = $app_class->module_root_namespace;
-  $class->config( namespace => $ns );
+
+  my $module_root_namespace = $app_class->module_root_namespace;
+  $class->config( namespace => $module_root_namespace || '' );
 };
 
 sub process { (shift)->approot(@_) }
 
-before 'register_actions' => sub {
-  my ( $self, $c ) = @_;
-  my $ns = $self->config->{namespace};
-  $c->dispatcher->register( $c => Catalyst::Action->new({
-    name      => 'base',
-    code      => sub {},
-    class     => $self->meta->name,
-    namespace => $ns,
-    reverse   => join('/',$ns),
-    attributes => {
-      Chained     => [ '/' ],
-      PathPart    => [ $ns ],
-      CaptureArgs => [ 0 ],
-    }
-  }));
-};
-
-sub approot :Chained('.') :PathPart('') :Args {
+sub approot :Chained :PathPrefix :Args {
   my ($self, $c, @args) = @_;
-  
+
   # Handle url string mode:
   if(scalar(@args) == 1 && $args[0] =~ /^\//) {
     my $url = $args[0];
@@ -104,7 +87,6 @@ sub approot :Chained('.') :PathPart('') :Args {
   
   $self->dispatch($c, @args);
 }
-
 
 sub end : ActionClass('RenderView') {}
 

--- a/lib/RapidApp/Controller/DefaultRoot.pm
+++ b/lib/RapidApp/Controller/DefaultRoot.pm
@@ -68,10 +68,26 @@ before 'COMPONENT' => sub {
   $class->config( namespace => $ns );
 };
 
-
 sub process { (shift)->approot(@_) }
 
-sub approot :Path {
+before 'register_actions' => sub {
+  my ( $self, $c ) = @_;
+  my $ns = $self->config->{namespace};
+  $c->dispatcher->register( $c => Catalyst::Action->new({
+    name      => 'base',
+    code      => sub {},
+    class     => $self->meta->name,
+    namespace => $ns,
+    reverse   => join('/',$ns),
+    attributes => {
+      Chained     => [ '/' ],
+      PathPart    => [ $ns ],
+      CaptureArgs => [ 0 ],
+    }
+  }));
+};
+
+sub approot :Chained('.') :PathPart('') :Args {
   my ($self, $c, @args) = @_;
   
   # Handle url string mode:

--- a/lib/RapidApp/Controller/DirectCmp.pm
+++ b/lib/RapidApp/Controller/DirectCmp.pm
@@ -9,7 +9,7 @@ use namespace::autoclean;
 
 use RapidApp::Util qw(:all);
 
-sub base :Chained('/') :PathPart('rapidapp/module') :CaptureArgs(0) {}
+sub base :Chained :PathPrefix :CaptureArgs(0) {}
 
 # This is a special controller designed to render a single RapidApp 
 # Module in its own Viewport (i.e. in an iFrame)

--- a/lib/RapidApp/Controller/DirectCmp.pm
+++ b/lib/RapidApp/Controller/DirectCmp.pm
@@ -9,16 +9,18 @@ use namespace::autoclean;
 
 use RapidApp::Util qw(:all);
 
+sub base :Chained('/') :PathPart('rapidapp/module') :CaptureArgs(0) {}
+
 # This is a special controller designed to render a single RapidApp 
 # Module in its own Viewport (i.e. in an iFrame)
 
-sub default :Path {
+sub default :Chained('base') :PathPart('') :Args {
   my ($self, $c, @args) = @_;
   # Fallback to 'direct'
   return $self->direct($c,@args);
 }
 
-sub direct :Local {
+sub direct :Chained('base') :Args {
   my ($self, $c, @args) = @_;
 
   $c->req->params->{__no_hashnav_redirect} = 1;
@@ -27,7 +29,7 @@ sub direct :Local {
   return $c->redispatch_public_path(@args);
 }
 
-sub printview :Local {
+sub printview :Chained('base') :Args {
   my ($self, $c, @args) = @_;
 
   $c->req->params->{__no_hashnav_redirect} = 1;
@@ -36,7 +38,7 @@ sub printview :Local {
   return $c->redispatch_public_path(@args);
 }
 
-sub navable :Local {
+sub navable :Chained('base') :Args {
   my ($self, $c, @args) = @_;
   
   # Return a one-off AppTab with a tab pointing to the supplied module 

--- a/lib/RapidApp/Module/StorCmp/Role/DbicLnk.pm
+++ b/lib/RapidApp/Module/StorCmp/Role/DbicLnk.pm
@@ -205,11 +205,10 @@ sub _build_ResultClass {
   return $self->ResultSource->schema->class($source_name);
 }
 
-
 has 'TableSpec' => ( is => 'ro', isa => 'RapidApp::TableSpec', lazy_build => 1 );
 sub _build_TableSpec {
   my $self = shift;
-  
+
   my $table = $self->ResultClass->table;
   $table = (split(/\./,$table,2))[1] || $table; #<-- get 'table' for both 'db.table' and 'table' format
   my %opt = (
@@ -222,9 +221,13 @@ sub _build_TableSpec {
   $opt{updatable_colspec} = $self->updatable_colspec if (defined $self->updatable_colspec);
   $opt{creatable_colspec} = $self->creatable_colspec if (defined $self->creatable_colspec);
   $opt{always_fetch_colspec} = $self->always_fetch_colspec if (defined $self->always_fetch_colspec);
-  
+
+  if (!exists $opt{cache} && $self->app->rapidApp->use_cache) {
+    $opt{cache} = $self->app->rapidApp->cache;
+  }
+
   my $TableSpec = RapidApp::TableSpec::DbicTableSpec->new(%opt);
-  
+
   $TableSpec->apply_natural_column_order if ($self->natural_column_order);
   
   return $TableSpec;

--- a/lib/RapidApp/RapidApp.pm
+++ b/lib/RapidApp/RapidApp.pm
@@ -220,7 +220,9 @@ sub incRequestCount {
 
 # RapidApp System Cache
 has 'use_cache' => ( is => 'ro', lazy => 1, default => (
-	defined $ENV{RAPIDAPP_NO_CACHE} ? $ENV{RAPIDAPP_NO_CACHE} : 1
+	defined $ENV{RAPIDAPP_NO_CACHE}
+		? ( $ENV{RAPIDAPP_NO_CACHE} ? 0 : 1 )
+		: 1
 ));
 
 has 'cache_class' => ( is => 'ro', lazy => 1, default => 'CHI' );

--- a/lib/RapidApp/RapidApp.pm
+++ b/lib/RapidApp/RapidApp.pm
@@ -9,6 +9,7 @@ with 'Catalyst::Component::ApplicationAttribute';
 
 use RapidApp::Util qw(:all);
 use Time::HiRes qw(gettimeofday);
+use File::Spec;
 
 # the package name of the catalyst application, i.e. "GreenSheet" or "HOPS"
 has 'catalystAppClass', is => 'ro', isa => 'Str', lazy => 1,
@@ -88,7 +89,6 @@ sub _load_root_module {
   $self->rootModule($self->rootModuleClass->timed_new($mParams));
   
 }
-
 
 sub performModulePreload {
 	my $self= shift;
@@ -217,5 +217,42 @@ sub incRequestCount {
 	my $self= shift;
 	$self->_requestCount($self->_requestCount+1);
 }
+
+# RapidApp System Cache
+has 'use_cache' => ( is => 'ro', lazy => 1, default => 1 );
+
+has 'cache_class' => ( is => 'ro', lazy => 1, default => 'CHI' );
+
+has 'cache_opts' => ( is => 'ro', predicate => 'has_cache_opts' );
+
+has 'cache' => ( is => 'ro', default => sub {
+	my ( $self ) = @_;
+	my %cache_opts;
+	if ($self->has_cache_opts) {
+		%cache_opts = %{$self->cache_opts};
+	} else {
+		my $tmpdir = File::Spec->tmpdir() or croak("No tmpdir on this system. Upgrade File::Spec?");
+		my $cachedir = File::Spec->catfile( $tmpdir, $self->cache_key );
+		%cache_opts = (
+			driver => 'File',
+			root_dir => $cachedir,
+			depth => 5,
+		);
+	}
+	my $cache_class = $self->cache_class;
+	Catalyst::Utils::ensure_class_loaded($cache_class);
+	my $cache = $cache_class->new( %cache_opts );
+
+	return $cache;
+});
+
+has 'cache_key' => ( is => 'ro', lazy => 1, default => sub {
+	my ( $self ) = @_;
+	my $class = ref $self;
+	$class =~ s/::/_/g;
+	return join('_',
+		RapidApp => $class, $RapidApp::VERSION, $DBIx::Class::VERSION,
+	);
+});
 
 1;

--- a/lib/RapidApp/Role/CatalystApplication.pm
+++ b/lib/RapidApp/Role/CatalystApplication.pm
@@ -143,7 +143,20 @@ sub setupRapidApp {
   #  #  if($app->debug);
   #  push @inject,['RapidApp::Controller::DefaultRoot', 'Controller::RapidApp::Root'];
   #}
-  
+
+  my $has_root = 0;
+
+  for (keys %{ $app->components }) {
+    my $component = $app->components->{$_};
+    if ($component->can('action_namespace')) {
+      $has_root = 1 if $component->action_namespace eq '';
+    }
+  }
+
+  unless ($has_root) {
+    # push @inject, ;
+  }
+
   # Controllers:
   push @inject, (
     ['RapidApp::Controller::DefaultRoot'             => 'Controller::RapidApp::Root'             ],
@@ -154,7 +167,9 @@ sub setupRapidApp {
   );
   
   $app->injectUnlessExist( @{$_} ) for (@inject);
-  
+
+  use DDP; p($app->components);
+
 };
 
 sub root_module_controller {

--- a/lib/RapidApp/Role/CatalystApplication.pm
+++ b/lib/RapidApp/Role/CatalystApplication.pm
@@ -104,7 +104,7 @@ sub application_has_root_controller {
   for (keys %{ $app->components }) {
     my $component = $app->components->{$_};
     if ($component->can('action_namespace')) {
-      return 1 if $component->action_namespace eq '';
+      return 1 if $component->action_namespace($app) eq '';
     }
   }
   return 0;

--- a/lib/RapidApp/Role/CatalystApplication.pm
+++ b/lib/RapidApp/Role/CatalystApplication.pm
@@ -167,9 +167,6 @@ sub setupRapidApp {
   );
   
   $app->injectUnlessExist( @{$_} ) for (@inject);
-
-  use DDP; p($app->components);
-
 };
 
 sub root_module_controller {

--- a/lib/RapidApp/TableSpec.pm
+++ b/lib/RapidApp/TableSpec.pm
@@ -457,8 +457,9 @@ sub apply_permission_roles_to_datastore_columns {
 	#scream($self->roles_permissions_columns_map);
 }
 
-
-
+# If TableSpec should be cached, then here we need a Cache::Cache
+# object, which is given on DbicLnk if use_cache is on.
+has 'cache' => ( is => 'ro', predicate => 'has_cache' );
 
 no Moose;
 __PACKAGE__->meta->make_immutable;

--- a/lib/RapidApp/Template/Controller.pm
+++ b/lib/RapidApp/Template/Controller.pm
@@ -46,8 +46,8 @@ sub BUILD {
       namespace => $ns,
       reverse   => join('/',$ns,'tpl'),
       attributes => {
-        Chained  => [ '/' ],
-        PathPart => [ $path ],
+        Chained    => ['/'],
+        PathPrefix => [''],
       }
     }));
   }
@@ -62,8 +62,8 @@ sub BUILD {
       namespace => $ns,
       reverse   => join('/',$ns,'tple'),
       attributes => {
-        Chained  => [ '/' ],
-        PathPart => [ $path ],
+        Chained    => ['/'],
+        PathPrefix => [''],
       }
     }));
   }
@@ -277,7 +277,7 @@ sub _resolve_template_name {
   return $template;
 }
 
-sub base :Chained('/') :PathPart('rapidapp/template') :CaptureArgs(0) {}
+sub base :Chained :PathPrefix :CaptureArgs(0) {}
 
 # TODO: see about rendering with Catalyst::View::TT or a custom View
 sub view :Chained('base') :Args {

--- a/lib/RapidApp/Template/Controller.pm
+++ b/lib/RapidApp/Template/Controller.pm
@@ -43,7 +43,7 @@ sub BUILD {
     $c->dispatcher->register( $c => Catalyst::Action->new({
       name      => 'tpl',
       code      => $self->can('tpl'),
-      class     => $self,
+      class     => $self->meta->name,
       namespace => $ns,
       reverse   => join('/',$ns,'tpl'),
       attributes => {
@@ -60,7 +60,7 @@ sub BUILD {
     $c->dispatcher->register( $c => Catalyst::Action->new({
       name      => 'tple',
       code      => $self->can('tple'),
-      class     => $self,
+      class     => $self->meta->name,
       namespace => $ns,
       reverse   => join('/',$ns,'tple'),
       attributes => {

--- a/lib/RapidApp/Template/Controller/Dispatch.pm
+++ b/lib/RapidApp/Template/Controller/Dispatch.pm
@@ -21,15 +21,20 @@ before 'COMPONENT' => sub {
   my $app_class = ref $_[0] || $_[0];
   
   my $cnf = $app_class->config->{'Model::RapidApp'} || {};
-  
+
   $class->config( 
     root_template        => $cnf->{root_template} || 'rapidapp/default_root_template.html',
-    root_template_prefix => $cnf->{root_template_prefix}
+    root_template_prefix => $cnf->{root_template_prefix},
   );
+
+  unless ($app_class->application_has_root_controller) {
+    $class->config( action => {
+      default => { Path => '/' },
+    });
+  } 
+
 };
 
-# I think this is with the Chained method now only relevant for
-# being called - GETTY
 sub default {
   my ($self, $c, @args) = @_;
 
@@ -50,7 +55,5 @@ sub default {
   $template =~ s/\/+/\//g; #<-- strip any double //
   return $c->template_controller->view($c, $template);
 }
-
-
 
 1;

--- a/lib/RapidApp/Template/Controller/Dispatch.pm
+++ b/lib/RapidApp/Template/Controller/Dispatch.pm
@@ -22,19 +22,15 @@ before 'COMPONENT' => sub {
   
   my $cnf = $app_class->config->{'Model::RapidApp'} || {};
   
-  # Claim the root namespace if the root module controller has 
-  # been setup at a different namespace
-  my $ns = $app_class->module_root_namespace;
-  $class->config( namespace => '' ) if ($ns && $ns ne '');
-
   $class->config( 
     root_template        => $cnf->{root_template} || 'rapidapp/default_root_template.html',
     root_template_prefix => $cnf->{root_template_prefix}
   );
 };
 
-
-sub default :Path {
+# I think this is with the Chained method now only relevant for
+# being called - GETTY
+sub default {
   my ($self, $c, @args) = @_;
 
   my $cfg = $self->config;


### PR DESCRIPTION
Implemented caching into RapidApp with the purpose to cache the
massive colspec_test calls which are happening at the startup of
RapidApp.

The cache is implemented via CHI, and uses by default a temporary
directory of the system, that is build based on your application name,
the RapidApp Version and the DBIx::Class Version. With the time and
with more use cases, we will finetune this key, but you would also be
able set it via cache_key, to set your own logic base for this.

The bigger problem here, was finding the right spot to cache. A
caching directly at colspec_test was the first plan, but this sadly
failed horrible, as the amount of recursive calls inside colspec_test
and the amount of calls to colspec_test had the startup time exploded.
But then I found the right place a step higher at the
colspec_select_columns function, which is also not using more
information as colspec_test itself, which allowed us to (nearly) only
use the colspecs and the columns as caching key. We additionally spice
the key with a deparsed md5ed stringification of the functions evolved
in the process of generation this cache, this allows even to edit
those functions and the cache realizes that it needs to be rebuild.

The speed of the startup time before the cache is there is probably
5% higher, but the startup time with a filled cache will reduce to
around 33% of the previous startup time without any cache
implementation. Those numbers come from a project with a giant amount
of databases, tables and columns, the speed gain will not be
significant on projects with low amount of database tables and
columns.
