### PR TITLE
Call ->_setup after reblessing in MetaKeys::Loader->new

### DIFF
--- a/lib/RapidApp/Util/MetaKeys/Loader.pm
+++ b/lib/RapidApp/Util/MetaKeys/Loader.pm
@@ -50,6 +50,8 @@ sub new {
     Class::C3::reinitialize() if $] < 5.009005;
   }
 
+  $self->_setup;
+
   return $self;
 }
 


### PR DESCRIPTION
`Schema::Loader::DBI->new` doesn't rebless when using a custom `loader_class`, so its call to `->_setup` doesn't call the right subclass method.

An upcoming change to Schema::Loader introduces caching of table info by wrapping the relevant methods in `->_setup`, which becomes less effective if it's not called on the subclass.