### PR TITLE
Silence warnings under 0.0829xx-to-be

### DIFF
--- a/lib/RapidApp/DBIC/Component/VirtualColumns.pm
+++ b/lib/RapidApp/DBIC/Component/VirtualColumns.pm
@@ -328,11 +328,11 @@ column is virtual or not.
 =cut
 
 # keep as compat shim for 0.0828xx DBIC
-sub column_info {
+sub column_info :DBIC_method_is_indirect_sugar {
     $_[0]->columns_info([ $_[1] ])->{$_[1]};
 }
 
-sub columns_info {
+sub columns_info :DBIC_method_is_bypassable_resultsource_proxy {
     my( $self, $colnames ) = @_;
 
     my %virt_cols;

--- a/lib/RapidApp/DBIC/Component/VirtualColumnsExt.pm
+++ b/lib/RapidApp/DBIC/Component/VirtualColumnsExt.pm
@@ -1,10 +1,22 @@
 package RapidApp::DBIC::Component::VirtualColumnsExt;
+use strict;
+use warnings;
+
 #use base 'DBIx::Class';
 # this is for Attribute::Handlers:
 require base; base->import('DBIx::Class');
 
-use strict;
-use warnings;
+### FIXME - not sure why the above happens at runtime, but not digging in
+### due to severe lack of time
+###
+### Still we need to apply the markers otherwise things will be *LOUD*
+for my $m (qw( has_column columns )) {
+    attributes->import(
+        __PACKAGE__,
+        __PACKAGE__->can($m),
+        'DBIC_method_is_bypassable_resultsource_proxy',
+    );
+}
 
 use RapidApp::Util qw(:all);
 


### PR DESCRIPTION
Essentially implements the conservative variant as described in
https://github.com/dbsrgits/dbix-class/commit/28ef94683

This is safe to use on older DBIC versions as well.
