### PR TITLE
Expose the SearchBox per-column condition building method

### DIFF
--- a/lib/RapidApp/Module/Grid/SearchBox.pm
+++ b/lib/RapidApp/Module/Grid/SearchBox.pm
@@ -57,6 +57,25 @@ has 'documentation',
 
 
 # Every subclass must implement this method:
+
+=head2 chain_query_search_rs
+
+  $modified_resultset = $searchbox->chain_query_search_rs( $resultset, $params );
+  # where $params may contain:
+  {
+    query => $search_text,
+    columns => \@column_name_list,
+  }
+
+This method is called by the Grid to apply the QuickSearch query information in
+C<$params> to the C<$resultset>, returning a chained C<$modified_resultset>.
+
+If the C<$params> do not contain a C<'query'> string, this returns the C<$resultset>
+un-changed.  If the C<$params> describe a search that does not search any columns,
+this method returns a resultset that finds zero rows.
+
+=cut
+
 sub chain_query_search_rs {
   my ($self, $Rs, $opt) = @_;
   

--- a/lib/RapidApp/Module/Grid/SearchBox/Normal.pm
+++ b/lib/RapidApp/Module/Grid/SearchBox/Normal.pm
@@ -57,11 +57,25 @@ has '_db_is_Postgres', is => 'ro', lazy => 1, default => sub {
 }, isa => Bool;
 
 
+=head2 chain_query_search_rs
+
+  $modified_resultset = $searchbox->chain_query_search_rs( $resultset, $params );
+
+This method is called by the Grid to apply the QuickSearch query information in
+C<$params> to the C<$resultset>, returning a chained C<$modified_resultset>.
+
+If the C<$params> do not contain a C<'query'> string, this returns the C<$resultset>
+un-changed.  If the C<$params> describe a search that does not search any columns,
+this method returns a resultset that finds zero rows.
+
+=cut
+
 sub chain_query_search_rs {
   my ($self, $Rs, $opt) = @_;
   
   return $Rs unless (ref($opt)||'' eq 'HASH');
-  my $query = $opt->{query} or return $Rs;
+  my $query = $opt->{query};
+  return $Rs unless defined $query && length $query;
   
   my $search = $self->_get_query_condition_list($Rs,$opt) || [];
   
@@ -78,69 +92,85 @@ sub chain_query_search_rs {
 
 
 sub _get_query_condition_list {
- my ($self, $Rs, $opt, $attr) = @_;
+  my ($self, $Rs, $opt, $attr) = @_;
   
   $self->_enforce_valid_opt($opt);
-  my $query = $opt->{query};
-  
-  my $Grid = $self->grid_module;
-  
   $attr ||= $self->{__current_attr} || { join => {} };
   
   my @search = ();
   for my $col (@{$opt->{columns}}) {
-    my $cnf  = $Grid->get_column($col) or die "field/column '$col' not found!";
-    
-    my $exact = $self->exact_matches;
-    
-    # Force to exact mode via optional TableSpec column cnf override: (LEGACY)
-    $exact = 1 if (
-      exists $cnf->{quick_search_exact_only}
-      && jstrue($cnf->{quick_search_exact_only})
-    );
-
-    my $dtype    = $cnf->{broad_data_type} || 'text';
-    my $dbicname = $Grid->_extract_hash_inner_AS( $Grid->resolve_dbic_colname($col,$attr->{join}) );
-
-    # For numbers, force to 'exact' mode and discard (return undef) for queries
-    # which are not numbers (since we already know they will not match anything). 
-    # This is also now safe for PostgreSQL which complains when you try to search
-    # on a numeric column with a non-numeric value:
-    if ($dtype eq 'integer') {
-      next unless $query =~ /^[+-]*[0-9]+$/;
-      $exact = 1;
-    }
-    elsif ($dtype eq 'number') {
-      next unless (
-        looks_like_number( $query )
-      );
-      $exact = 1;
-    }
-
-    # Special-case: pre-validate enums (Github Issue #56)
-    my $enumVh = $cnf->{enum_value_hash};
-    if ($enumVh) {
-      next unless ($enumVh->{$query});
-      $exact = 1;
-    }
-
-    # New for GitHub Issue #97
-    my $strf = $cnf->{search_operator_strf};
-    my $s = $strf ? sub { sprintf($strf,shift) } : sub { shift };
-
-    # 'text' is the only type which can do a LIKE (i.e. sub-string)
-    my $cond = $exact
-      ? $Grid->_op_fuse($dbicname => { $s->($self->exact_operator) => $query })
-      : $Grid->_op_fuse($dbicname => { $s->($self->like_operator) => join('%','',$query,'') });
-
-    push @search, $cond;
+    my $cond = $self->get_condition_for_column($Rs, { col => $col, %$opt }, $attr);
+    push @search, $cond if defined $cond;
   }
 
   return \@search
 }
 
+=head2 get_condition_for_column
 
+  $sql_abstract_clause= $searchbox->get_condition_for_column( $resultset, \%opts, \%attrs )
+  # where %opts contains:
+  {
+    query   => $query_text,
+    col     => $rapidapp_column_name, # may be virtual
+  }
+  # and %attrs is the DBIC attributes to be applied with the search
 
+This method generates a DBIC clause for one column.  In this SearchBox implementation,
+the clauses for each column are "OR"ed to create the final DBIC search clause.
+Subclasses may use this method to tap into the default per-column behavior, or override
+behavior for specific columns.
 
+This method should return C<undef> if this column cannot match the search phrase,
+such as if the user searches for alphanumeric text and the column can only hold integers.
+
+=cut
+
+sub get_condition_for_column {
+  my ($self, $Rs, $opt, $attr)= @_;
+  my $Grid = $self->grid_module;
+  my $col  = $opt->{col};
+  my $cnf  = $Grid->get_column($col) or die "field/column '$col' not found!";
+  my $query = $opt->{query};
+  my $exact = $self->exact_matches;
+  
+  # Force to exact mode via optional TableSpec column cnf override: (LEGACY)
+  $exact = 1 if (
+    exists $cnf->{quick_search_exact_only}
+    && jstrue($cnf->{quick_search_exact_only})
+  );
+
+  my $dtype    = $cnf->{broad_data_type} || 'text';
+  my $dbicname = $Grid->_extract_hash_inner_AS( $Grid->resolve_dbic_colname($col,$attr->{join}) );
+
+  # For numbers, force to 'exact' mode and discard (return undef) for queries
+  # which are not numbers (since we already know they will not match anything).
+  # This is also now safe for PostgreSQL which complains when you try to search
+  # on a numeric column with a non-numeric value:
+  if ($dtype eq 'integer') {
+    return undef unless $query =~ /^[+-]*[0-9]+$/;
+    $exact = 1;
+  }
+  elsif ($dtype eq 'number') {
+    return undef unless looks_like_number( $query );
+    $exact = 1;
+  }
+
+  # Special-case: pre-validate enums (Github Issue #56)
+  my $enumVh = $cnf->{enum_value_hash};
+  if ($enumVh) {
+    return undef unless $enumVh->{$query};
+    $exact = 1;
+  }
+
+  # New for GitHub Issue #97
+  my $strf = $cnf->{search_operator_strf};
+  my $s = $strf ? sub { sprintf($strf,shift) } : sub { shift };
+
+  # 'text' is the only type which can do a LIKE (i.e. sub-string)
+  return $exact
+    ? $Grid->_op_fuse($dbicname => { $s->($self->exact_operator) => $query })
+    : $Grid->_op_fuse($dbicname => { $s->($self->like_operator) => join('%','',$query,'') });
+}
 
 1;


### PR DESCRIPTION
The default implementation of SearchBox calculates a condition
for each searched column and then "OR"s them together.  The
implementation of these conditions is complex and relies on
private methods.  In order for subclasses to be able to alter
the implementation without completely rewriting it, they need
access to call the per-column method.  This change refactors
the _get_query_condition_list so that the per-column portion
is public, as "get_condition_for_column".

I also added documentation for the API of chain_query_search_rs
to both SearchBox and SearchBox::Normal