### PR TITLE
Use weak reference to prevent memory leak.

### DIFF
--- a/lib/RapidApp/Handler.pm
+++ b/lib/RapidApp/Handler.pm
@@ -3,7 +3,7 @@ use Moose;
 
 use RapidApp::Util qw(:all);
 
-has 'scope'		=> ( is => 'rw', default => undef, isa => 'Maybe[Object]' );
+has 'scope'		=> ( is => 'rw', default => undef, isa => 'Maybe[Object]', weak_ref => 1 );
 has 'method'	=> ( is => 'rw', default => undef, isa => 'Maybe[Str]' );
 has 'code'		=> ( is => 'rw', default => undef, isa => 'Maybe[CodeRef]' );
 


### PR DESCRIPTION
Memory leak testing showed circular references due to the "scope" attribute of RapidApp::Handler.  Changing this attribute to a weak reference fixes the problem, and is appropriate since the handler doesn't "own" the object references by the scope attribute.