### PR TITLE
remove use of MooseX::MarkAsMethods

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -76,7 +76,7 @@ Catalyst::Controller::SimpleCAS  = 1.002
 
 Catalyst::Model::DBIC::Schema = 0.65
 DBIx::Class                   = 0.082842
-DBIx::Class::Schema::Loader   = 0.07049
+DBIx::Class::Schema::Loader   = 0.07050
 DBIx::Class::Schema::Diff     = 1.07
 SQL::Translator               = 1.62
 SQL::Abstract                 = 1.87
@@ -92,7 +92,6 @@ namespace::autoclean          = 0.28
 Moose                         = 2.2013
 Moo                           = 2.004000
 Type::Tiny                    = 1.000005
-MooseX::MarkAsMethods         = 0.15
 MooseX::NonMoose              = 0.26
 MooseX::Traits                = 0.12
 Class::Load                   = 0.22

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB.pm
@@ -3,7 +3,7 @@ package # hide from PAUSE
      TestRA::ChinookDemo::DB;
 
 use Moose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Schema';
 
 __PACKAGE__->load_namespaces;

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Album.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Album.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("Album");

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Artist.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Artist.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("Artist");

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Customer.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Customer.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("Customer");

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Employee.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Employee.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("Employee");

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Genre.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Genre.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("Genre");

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Invoice.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Invoice.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("Invoice");

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/InvoiceLine.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/InvoiceLine.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("InvoiceLine");

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/MediaType.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/MediaType.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("MediaType");

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Playlist.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Playlist.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("Playlist");

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/PlaylistTrack.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/PlaylistTrack.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("PlaylistTrack");

--- a/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Track.pm
+++ b/t/var/testapps/TestRA-ChinookDemo/lib/TestRA/ChinookDemo/DB/Result/Track.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Moose;
 use MooseX::NonMoose;
-use MooseX::MarkAsMethods autoclean => 1;
+
 extends 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table("Track");


### PR DESCRIPTION
fixes #80

According to
https://github.com/dbsrgits/dbix-class-schema-loader/pull/21, the fix that removes the need for MooseX::MAM is merged in as of dbix-class-chema-loader v0.07050.